### PR TITLE
Fix np.bool AttributeError

### DIFF
--- a/src/odrpack/result.py
+++ b/src/odrpack/result.py
@@ -7,7 +7,7 @@ __all__ = ['OdrResult']
 
 F64Array = NDArray[np.float64]
 I32Array = NDArray[np.int32]
-BoolArray = NDArray[np.bool]
+BoolArray = NDArray[bool]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
np.bool is deprecated as of NumPy 1.20, and throws an error as of NumPy 1.24.